### PR TITLE
Remove dependency on foldl package

### DIFF
--- a/Text/MMark.hs
+++ b/Text/MMark.hs
@@ -122,8 +122,8 @@ module Text.MMark
   , useExtension
   , useExtensions
     -- * Scanning
-  , runScanner
-  , runScannerM
+  , fold
+  , foldM
   , projectYaml
     -- * Rendering
   , render )

--- a/Text/MMark/Extension.hs
+++ b/Text/MMark/Extension.hs
@@ -51,9 +51,6 @@ module Text.MMark.Extension
   , Inline (..)
   , inlineTrans
   , inlineRender
-    -- * Scanner construction
-  , scanner
-  , scannerM
     -- * Utils
   , asPlainText
   , headerId
@@ -63,7 +60,6 @@ where
 import Data.Monoid hiding ((<>))
 import Lucid
 import Text.MMark.Internal
-import qualified Control.Foldl as L
 
 -- | Create an extension that performs a transformation on 'Block's of
 -- markdown document.
@@ -103,22 +99,3 @@ inlineRender
   :: ((Inline -> Html ()) -> Inline -> Html ())
   -> Extension
 inlineRender f = mempty { extInlineRender = Render f }
-
--- | Create a 'L.Fold' from an initial state and a folding function.
-
-scanner
-  :: a                 -- ^ Initial state
-  -> (a -> Bni -> a)   -- ^ Folding function
-  -> L.Fold Bni a      -- ^ Resulting 'L.Fold'
-scanner a f = L.Fold f a id
-{-# INLINE scanner #-}
-
--- | Create a 'L.FoldM' from an initial state and a folding function.
-
-scannerM
-  :: Monad m
-  => m a               -- ^ Initial state
-  -> (a -> Bni -> m a) -- ^ Folding function
-  -> L.FoldM m Bni a   -- ^ Resulting 'L.FoldM'
-scannerM a f = L.FoldM f a return
-{-# INLINE scannerM #-}

--- a/mmark.cabal
+++ b/mmark.cabal
@@ -33,7 +33,6 @@ library
                     , data-default-class
                     , deepseq          >= 1.3  && < 1.5
                     , email-validate   >= 2.2  && < 2.4
-                    , foldl            >= 1.2  && < 1.4
                     , lucid            >= 2.6  && < 3.0
                     , megaparsec       >= 6.1  && < 7.0
                     , modern-uri       >= 0.1.1 && < 0.2


### PR DESCRIPTION
`pipes` avoids depending on `foldl` by presenting an API suitable for
the `Control.Foldl.purely` and `Control.Foldl.impurely` functions, or for a fold not
built from `Control.Foldl.Fold`.

This is a food for thought sort of PR, I don't really know if you'd want to merge it or keep `foldl` as an inherent part of the `mmark` API.

Btw, I ripped the implementations of `fold` and `foldM` straight from `foldl`, I hope that's not a licensing issue.